### PR TITLE
Added .trim() to avoid erros due accidental whitespace after name

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ app.get('/', function(req, res){
 app.post('/find', function(req, res) {
 
   var data = {
-    name: req.body.first_name + ' ' + req.body.last_name,
+    name: req.body.first_name.trim() + ' ' + req.body.last_name.trim(),
     domain: req.body.domain
   };
 


### PR DESCRIPTION
Before, if there were any whitespace after the name, such as 'Elon ', the script would return an error. By adding .trim() method this problem is solved.